### PR TITLE
make getHandlerList static in ShopDeleteEvent.java

### DIFF
--- a/src/main/java/org/maxgamer/quickshop/Event/ShopDeleteEvent.java
+++ b/src/main/java/org/maxgamer/quickshop/Event/ShopDeleteEvent.java
@@ -34,7 +34,7 @@ public class ShopDeleteEvent extends Event implements Cancellable {
     }
 
     @NotNull
-    public HandlerList getHandlerList() {return handlers;}
+    public static HandlerList getHandlerList() {return handlers;}
     @Override
     public boolean isCancelled() {
         return this.cancelled;


### PR DESCRIPTION
According to the documentation the method "getHandlerList" must be static. This should solve another NullPointerException problem
https://bukkit.gamepedia.com/Event_API_Reference#Creating_Custom_Events